### PR TITLE
ci: route E2E job to Blacksmith 4 vCPU runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,7 +543,11 @@ jobs:
   e2e:
     name: E2E Tests
     needs: [setup, build]
-    runs-on: ubuntu-latest
+    # Blacksmith 4 vCPU / 8 GB runner. The default GitHub-hosted ubuntu-latest
+    # (2 vCPU / 7 GB) saturates under Playwright + Next.js prod server + Postgres
+    # + Redis, causing flake on long-timeout assertions. Other jobs stay on
+    # ubuntu-latest — only the E2E job is CPU-bound.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: needs.setup.outputs.has-api-changes == 'true' || needs.setup.outputs.has-app-changes == 'true'
     services:
       postgres:

--- a/apps/pokehub-app/router.ts
+++ b/apps/pokehub-app/router.ts
@@ -1,5 +1,6 @@
 import type { AppRouter } from '@pokehub/frontend/shared-app-router';
 
+// no-op: trigger nx affected to exercise Blacksmith E2E runner (PR #133)
 export const PokeHubRouter: AppRouter = {
   publicRoutes: [
     {


### PR DESCRIPTION
## Summary
- Swap the E2E job's `runs-on` from `ubuntu-latest` (2 vCPU / 7 GB) to `blacksmith-4vcpu-ubuntu-2404` (4 vCPU / 8 GB) to fix CPU saturation under Playwright + Next.js prod server + Postgres + Redis
- All other jobs stay on GitHub-hosted runners — only the E2E job is CPU-bound
- One-time prerequisite: Blacksmith GitHub App installed on the repo (confirmed)

## Why
On `ubuntu-latest`, the E2E job has been flaky on long-timeout assertions (15 s) for tests that pass locally in <1 s — symptom of runner contention rather than test bugs. Reducing `workers: 2 → 1` would serialise the suite and add 4–5 min wall-clock; doubling the CPU keeps the suite parallel and addresses the root cause.

## Cost
Blacksmith 4 vCPU is effectively $0.008/min (2× the 2vCPU base rate, same per-minute price as a GitHub-hosted runner). E2E runs are ~10–15 min, so ~$0.08–$0.12 per run. Free tier covers 3,000 2vCPU-min/month (~100 E2E runs).

## Test plan
- [ ] Verify the E2E job runs on a Blacksmith runner (check Actions tab — runner name should start with `blacksmith-`)
- [ ] Verify the previously-flaky tests (`create-profile.spec.ts:470`, `settings.spec.ts:212`, team-editor/viewer specs) pass without timeout flake
- [ ] Confirm other jobs (typecheck, lint, test, build) still run on `ubuntu-latest`